### PR TITLE
Performance improvements

### DIFF
--- a/crwltrckr/app/controllers/crawl_projects_controller.rb
+++ b/crwltrckr/app/controllers/crawl_projects_controller.rb
@@ -6,6 +6,9 @@ class CrawlProjectsController < ApplicationController
 
   def show
     @crawl_project = CrawlProject.find(params[:id])
+    @crawl_project.hosts.each do |host|
+      host.refresh_stats
+    end
     @stats_keys = %w(id name crawl_active extract_active recrawl_enabled active_host_patterns found cached queued failed last_cached last_extraction)
   end
 

--- a/crwltrckr/app/controllers/dashboard_controller.rb
+++ b/crwltrckr/app/controllers/dashboard_controller.rb
@@ -1,6 +1,5 @@
 class DashboardController < ApplicationController
   def index
-    @rosalyn = "hellodfaffsd"
-    @crawl_projects = CrawlProject.all
+    @crawl_projects = CrawlProject.all.sample(3)
   end
 end

--- a/crwltrckr/app/models/host.rb
+++ b/crwltrckr/app/models/host.rb
@@ -7,23 +7,40 @@ class Host < ActiveRecord::Base
   serialize :stats, Hash
   has_and_belongs_to_many :crawl_projects
 
-  PIPELINES_HOST = "http://10.0.100.228:3000"
+#   PIPELINES_HOST = "http://10.0.100.228:3000"
 #   PIPELINES_HOST = "http://10.0.100.210:3001"
+  PIPELINES_HOST = "http://10.20.10.103:3000"
   CACHED_AGES_UPDATE_INTERVAL = 15 #days 
   STATS_UPDATE_INTERVAL = 1 #days 
 
   def get_stats
-    if self.stats['updated_at'] && self.stats['updated_at'] > Date.today - STATS_UPDATE_INTERVAL
-      return self.stats
+    if stats['updated_at'] && stats['updated_at'] > Date.today - STATS_UPDATE_INTERVAL
+      return stats
     end
-    self.stats = get_stats_from_pipelines()
-    self.stats['updated_at'] = Date.today
-    self.save
-    self.stats
+    stats.merge!(get_stats_from_pipelines())
+    stats['updated_at'] = Date.today
+    self.save!
+    if stats['cached_ages_updated_at'] && stats['cached_ages_updated_at'] > Date.today - CACHED_AGES_UPDATE_INTERVAL
+      return stats
+    end
+    stats['cached_ages'] = get_cached_ages_from_pipelines()
+    stats['cached_ages_updated_at'] = Date.today
+    self.save!
+    stats
+  end
+
+  def refresh_stats
+    stats['updated_at'] = nil
+    self.save!
+  end
+
+  def refresh_cached_ages
+    stats['cached_ages_updated_at'] = nil
+    self.save!
   end
 
   def get_stats_from_pipelines
-    path = "/hosts/#{self.pipelines_id}/stats.json"
+    path = "/hosts/#{pipelines_id}/stats.json"
     stats = self.class.get_json_from_pipelines(path)
     %w(cached queued found failed).each do |key|
       stats[key] = format_number(stats[key].to_i)
@@ -31,15 +48,10 @@ class Host < ActiveRecord::Base
     stats['regression_tests'] = format_regression_tests(stats["regression_tests"]) if stats["regression_tests"]
     stats['last_cached'] = date_to_days_ago(stats["last_cached"])
     stats['last_extraction'] = date_to_days_ago(stats["last_extraction"])
-    stats['cached_ages'] = get_cached_ages
     stats
   end
 
-  def get_cached_ages
-    if self.stats['cached_ages_updated_at'] && self.stats['cached_ages_updated_at'] > Date.today - CACHED_AGES_UPDATE_INTERVAL
-      return self.stats['cached_ages']
-    end
-    self.stats['cached_ages_updated_at'] = Date.today
+  def get_cached_ages_from_pipelines
     counts = []
     counts << input_age_count('cached', 91)
     counts << input_age_count('cached', 182, 91)
@@ -50,7 +62,7 @@ class Host < ActiveRecord::Base
   end
 
   def input_age_count(type='cached', days_ago_start=nil, days_ago_end=nil)
-    path = "/hosts/#{self.pipelines_id}/urls/stats.json?type=#{type}"
+    path = "/hosts/#{pipelines_id}/urls/stats.json?type=#{type}"
     path += "&days_ago_start=#{days_ago_start}" if days_ago_start
     path += "&days_ago_end=#{days_ago_end}" if days_ago_end
     count = self.class.get_json_from_pipelines(path)['count']

--- a/crwltrckr/app/views/layouts/application.html.haml
+++ b/crwltrckr/app/views/layouts/application.html.haml
@@ -16,6 +16,8 @@
           %div.navbar-header
             = link_to image_tag("logo.svg", :style => "height: 240%;"), "/", class: 'navbar-brand'
           %ul.nav.navbar-top-links.navbar-right
+            %li
+              = link_to "All Crawl Projects", crawl_projects_path
             - if current_user
               %li
                 = "#{current_user.email}"

--- a/crwltrckr/spec/models/host_spec.rb
+++ b/crwltrckr/spec/models/host_spec.rb
@@ -13,10 +13,12 @@ RSpec.describe Host, :type => :model do
     end
   end
 
-  describe '#stats' do
+  describe '#get_stats' do
     it 'gets stats from pipelines' do
       h = Host.new(pipelines_id: 103)
-      expect(h.stats).to be_truthy
+      h.get_stats
+      expect(h.stats['last_cached']).to be_truthy
     end
   end
+
 end


### PR DESCRIPTION
Cache host stats for 1 to 15 days, instead of querying pipelines for them every time.
